### PR TITLE
Escape pathfile cli argument for windows os.

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxws/AbstractJaxwsMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxws/AbstractJaxwsMojo.java
@@ -452,7 +452,7 @@ abstract class AbstractJaxwsMojo
             try
             {
                 File pathFile = createPathFile( cp );
-                cmd.createArg().setLine( "-pathfile " + pathFile.getAbsolutePath() );
+                cmd.createArg().setLine( "-pathfile " + "'" + pathFile.getAbsolutePath() +  "'" );
             }
             catch ( IOException ioe )
             {


### PR DESCRIPTION
We encounter an issue with foldername with spaces for the argument pathfile.

This PR will help fixing it.
