### PR TITLE
Marked plugins as thread-safe. Closes #40

### DIFF
--- a/src/main/java/org/codehaus/mojo/jaxws/MainWsGenMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxws/MainWsGenMojo.java
@@ -36,8 +36,6 @@
 
 package org.codehaus.mojo.jaxws;
 
-import java.io.File;
-import java.io.IOException;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -49,12 +47,15 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
+import java.io.File;
+import java.io.IOException;
+
 /**
  * Reads a JAX-WS service endpoint implementation class
  * and generates all of the portable artifacts for a JAX-WS web service.
  */
 @Mojo( name = "wsgen", defaultPhase = LifecyclePhase.PROCESS_CLASSES,
-        requiresDependencyResolution = ResolutionScope.RUNTIME )
+        requiresDependencyResolution = ResolutionScope.RUNTIME, threadSafe = true)
 public class MainWsGenMojo
     extends AbstractWsGenMojo
 {

--- a/src/main/java/org/codehaus/mojo/jaxws/MainWsImportMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxws/MainWsImportMojo.java
@@ -36,12 +36,12 @@
 
 package org.codehaus.mojo.jaxws;
 
-import java.io.File;
-
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+
+import java.io.File;
 
 /**
  * Parses wsdl and binding files and generates Java code needed to access it.
@@ -49,7 +49,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  * @author Kohsuke Kawaguchi
  */
 @Mojo( name = "wsimport", defaultPhase = LifecyclePhase.GENERATE_SOURCES,
-        requiresDependencyResolution = ResolutionScope.RUNTIME )
+        requiresDependencyResolution = ResolutionScope.RUNTIME, threadSafe = true)
 public class MainWsImportMojo
     extends WsImportMojo
 {

--- a/src/main/java/org/codehaus/mojo/jaxws/TestWsGenMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxws/TestWsGenMojo.java
@@ -35,14 +35,14 @@
  */
 package org.codehaus.mojo.jaxws;
 
-import java.io.File;
-
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+
+import java.io.File;
 
 /**
  * Reads a JAX-WS service endpoint implementation class
@@ -55,7 +55,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  *
  */
 @Mojo( name = "wsgen-test", defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES,
-        requiresDependencyResolution = ResolutionScope.TEST )
+        requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
 public class TestWsGenMojo
     extends AbstractWsGenMojo
 {

--- a/src/main/java/org/codehaus/mojo/jaxws/TestWsImportMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxws/TestWsImportMojo.java
@@ -36,13 +36,13 @@
 
 package org.codehaus.mojo.jaxws;
 
-import java.io.File;
-
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+
+import java.io.File;
 
 /**
  * Parses wsdl and binding files and generates Java code needed to access it
@@ -55,7 +55,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  * @author Kohsuke Kawaguchi
  */
 @Mojo( name = "wsimport-test", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES,
-        requiresDependencyResolution = ResolutionScope.TEST )
+        requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
 public class TestWsImportMojo
     extends WsImportMojo
 {


### PR DESCRIPTION
I checked the Mojos and didn't find anything that is not thread-safe. Also I did a lot of successful tests using Maven's parallel execution mode. Therefore they can be marked as thread-safe.