### PR TITLE
Sei lookup with javassist or classpath, incremental build support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,17 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <version>3.20.0-GA</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.9</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.sun.xml.ws</groupId>
       <artifactId>jaxws-tools</artifactId>
       <scope>runtime</scope>

--- a/src/main/java/org/codehaus/mojo/jaxws/AbstractJaxwsMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxws/AbstractJaxwsMojo.java
@@ -234,8 +234,7 @@ abstract class AbstractJaxwsMojo
      */
     protected abstract boolean isXnocompile();
 
-    protected String getExtraClasspath()
-    {
+    protected String getExtraClasspath() throws MojoExecutionException {
         return null;
     }
 
@@ -395,6 +394,7 @@ abstract class AbstractJaxwsMojo
         String launched = "";
         Commandline cmd = new Commandline();
 
+        String extraClasspath = getExtraClasspath();
         if ( executable != null )
         {
             // use JDK wsgen/wsimport or equivalent executable
@@ -402,10 +402,10 @@ abstract class AbstractJaxwsMojo
             if ( executable.isFile() && executable.canExecute() )
             {
                 cmd.setExecutable( executable.getAbsolutePath() );
-                if ( getExtraClasspath() != null )
+                if ( extraClasspath != null )
                 {
                     cmd.createArg().setLine( "-cp" );
-                    cmd.createArg().setValue( getExtraClasspath() );
+                    cmd.createArg().setValue(extraClasspath);
                 }
             }
             else
@@ -444,8 +444,7 @@ abstract class AbstractJaxwsMojo
             cmd.createArg().setValue( classpath.invokerPath );
             cmd.createArg().setLine( Invoker.class.getCanonicalName() );
             cmd.createArg().setLine( getMain() );
-            String extraCp = getExtraClasspath();
-            String cp = ( ( extraCp != null ) ? ( extraCp + File.pathSeparator ) : "" ) + classpath.cp;
+            String cp = ( ( extraClasspath != null ) ? ( extraClasspath + File.pathSeparator ) : "" ) + classpath.cp;
             try
             {
                 File pathFile = createPathFile( cp );
@@ -667,7 +666,7 @@ abstract class AbstractJaxwsMojo
      * Places the artifact in either the endorsed artifacts set or the normal
      * artifacts map.  It will only add those in "compile" and "runtime" scope
      * or those that are specifically endorsed.
-     * 
+     *
      * @param a artifact to sort
      * @param artifactsMap normal artifacts map
      * @param endorsedArtifacts endorsed artifacts set

--- a/src/main/java/org/codehaus/mojo/jaxws/AbstractJaxwsMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxws/AbstractJaxwsMojo.java
@@ -35,10 +35,7 @@
  */
 package org.codehaus.mojo.jaxws;
 
-import java.io.Closeable;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -64,11 +61,7 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.util.Os;
-import org.codehaus.plexus.util.cli.CommandLineException;
-import org.codehaus.plexus.util.cli.CommandLineUtils;
-import org.codehaus.plexus.util.cli.Commandline;
-import org.codehaus.plexus.util.cli.DefaultConsumer;
-import org.codehaus.plexus.util.cli.StreamConsumer;
+import org.codehaus.plexus.util.cli.*;
 
 /**
  *
@@ -478,9 +471,17 @@ abstract class AbstractJaxwsMojo
                 getLog().debug( fullCommand );
             }
 
-            StreamConsumer sc = new DefaultConsumer();
+            StreamConsumer sc;
+            if (verbose){
+                sc = new CommandLineUtils.StringStreamConsumer();
+            } else {
+                sc = new DefaultConsumer();
+            }
             if ( CommandLineUtils.executeCommandLine( cmd, sc, sc ) != 0 )
             {
+                if (verbose) {
+                    getLog().error(((CommandLineUtils.StringStreamConsumer) sc).getOutput());
+                }
                 throw new MojoExecutionException( "Invocation of " + launched + " failed - check output" );
             }
         }

--- a/src/main/java/org/codehaus/mojo/jaxws/FileStateRegistry.java
+++ b/src/main/java/org/codehaus/mojo/jaxws/FileStateRegistry.java
@@ -1,0 +1,120 @@
+package org.codehaus.mojo.jaxws;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.maven.plugin.MojoFailureException;
+
+import java.io.*;
+import java.util.HashMap;
+
+public class FileStateRegistry implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private HashMap<String, String> fileStateMap = new HashMap<String, String>();
+
+    private transient HashMap<String, String> newFileStateMap = new HashMap<String, String>();
+    private transient File registryData;
+
+    public FileStateRegistry(File registryData){
+        this.registryData = registryData;
+        registryData.getParentFile().mkdirs();
+        // check if accessible
+    }
+
+    /**
+     * Checks file state based on md5 sums
+     * @param file to check state
+     * @return <code>true</code> if file content differs from previous file state based on md5 sums otherwise
+     * <code>false</code>
+     * @throws MojoFailureException
+     */
+    public boolean isChanged(File file) throws MojoFailureException {
+        try {
+            String name = file.getCanonicalPath();
+            if(newFileStateMap.containsKey(name)){
+                return true;
+            }
+
+            String savedFileMd5 = fileStateMap.get(name);
+            String newFileMd5 = md5Sum(file);
+            if(savedFileMd5 != null && savedFileMd5.equals(newFileMd5)){
+                return false;
+            } else {
+                newFileStateMap.put(name, newFileMd5);
+            }
+        } catch (IOException e) {
+            throw new MojoFailureException("Unable to determine file state for " + file.getName(), e);
+        }
+        return true;
+    }
+
+    /**
+     * Create MD5 checksum of file contents
+     * @param file for which checksum will be calculated
+     * @return MD5 sum string of file contents
+     * @throws MojoFailureException
+     */
+    private String md5Sum(File file) throws MojoFailureException {
+        try {
+            return DigestUtils.md5Hex(new FileInputStream(file));
+        } catch (IOException e) {
+            throw new MojoFailureException("Unable to calculate md5 sum for file " + file.getName() );
+        }
+    }
+
+    /**
+     * Store checksum for provided file in persistent file
+     * @param file for which state should be persisted
+     * @throws MojoFailureException
+     */
+    public void store(File file) throws MojoFailureException {
+        FileOutputStream fis = null;
+        try {
+            String name = file.getCanonicalPath();
+            if(newFileStateMap.containsKey(name)) {
+                fileStateMap.put(name, newFileStateMap.remove(name));
+
+                fis = new FileOutputStream(registryData);
+                ObjectOutputStream ois = new ObjectOutputStream(fis);
+                ois.writeObject(this);
+            }
+        } catch (Exception e) {
+            throw new MojoFailureException("Unable to save file state registry " + registryData.getName() );
+        } finally {
+            if(fis != null) {
+                try {
+                    fis.close();
+                } catch (IOException e) {
+                    throw new Error(e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Load persistent state from state file
+     * @param registryData persistent state file
+     * @return registry initialized from state file
+     */
+    public static FileStateRegistry load(File registryData) {
+        FileInputStream fis = null;
+        try {
+            fis = new FileInputStream(registryData);
+            ObjectInputStream ois = new ObjectInputStream(fis);
+            FileStateRegistry fr = (FileStateRegistry) ois.readObject();
+            fr.registryData = registryData;
+            fr.newFileStateMap = new HashMap<String, String>();
+            return fr;
+        } catch (Exception e) {
+            return new FileStateRegistry(registryData);
+        } finally {
+            if(fis != null) {
+                try {
+                    fis.close();
+                } catch (IOException e) {
+                    throw new Error(e);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/codehaus/mojo/jaxws/Sei.java
+++ b/src/main/java/org/codehaus/mojo/jaxws/Sei.java
@@ -1,0 +1,121 @@
+package org.codehaus.mojo.jaxws;
+
+import javassist.ClassPool;
+import javassist.bytecode.AnnotationsAttribute;
+import javassist.bytecode.ClassFile;
+import javassist.bytecode.annotation.Annotation;
+import org.apache.maven.plugin.MojoExecutionException;
+
+import javax.jws.WebService;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+public final class Sei {
+    private static final ClassPool CLASS_POOL = ClassPool.getDefault();
+
+    public final boolean isChanged;
+    public final String name;
+    public final File classFile;
+    public final WebService webservice;
+
+    public Sei(String name) {
+        this.isChanged = true;
+        this.name = name;
+        this.classFile = null;
+        this.webservice = null;
+    }
+
+    public Sei(boolean isChanged, String name, WebService webservice, File classFile) throws IOException {
+        this.isChanged = isChanged;
+        this.name = name;
+        this.classFile = classFile.getCanonicalFile();
+        this.webservice = webservice;
+    }
+
+    public File jaxwsDir(File classesDir){
+        String[] nameParts = name.split("\\.");
+        if(nameParts.length == 1){
+            return  new File(classesDir, "jaxws");
+        }
+        StringBuffer sb = new StringBuffer(nameParts.length);
+        for(int i = 0, len = nameParts.length - 1, last = len -1; i < len; i++){
+            if(i == last) {
+                sb.append(nameParts[i]).append(File.separator).append("jaxws");
+            } else {
+                sb.append(nameParts[i]).append(File.separator);
+            }
+        }
+        return new File(classesDir, sb.toString());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Sei sei = (Sei) o;
+
+        if (!name.equals(sei.name)) return false;
+        return classFile != null ? classFile.equals(sei.classFile) : sei.classFile == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + (classFile != null ? classFile.hashCode() : 0);
+        return result;
+    }
+
+    public static class Type {
+        public final ClassFile classFile;
+        public final WebService webservice;
+
+        public Type(ClassFile classFile, WebService webservice){
+            this.classFile = classFile;
+            this.webservice = webservice;
+        }
+    }
+
+    public static Type findWebserviceAnnotation(File file) throws IOException, MojoExecutionException {
+        FileInputStream fis = null;
+        try {
+            fis = new FileInputStream(file);
+            ClassFile classFile = new ClassFile(new DataInputStream(fis));
+            Type result = null;
+            AnnotationsAttribute visible = (AnnotationsAttribute) classFile.getAttribute(AnnotationsAttribute.visibleTag);
+            AnnotationsAttribute invisible = (AnnotationsAttribute) classFile.getAttribute(AnnotationsAttribute.invisibleTag);
+            result = findWebServiceAnnotationForAnnotationsAttribute(classFile, visible);
+            if(result == null) {
+                result = findWebServiceAnnotationForAnnotationsAttribute(classFile, invisible);
+            }
+            return result;
+        } finally {
+            if(fis != null){
+                try {
+                    fis.close();
+                } catch (IOException e) {
+                    throw new Error(e);
+                }
+            }
+        }
+    }
+
+    private static Type findWebServiceAnnotationForAnnotationsAttribute(ClassFile classFile, AnnotationsAttribute attr) throws MojoExecutionException {
+        if (attr != null) {
+            Annotation[] anns = attr.getAnnotations();
+
+            for (javassist.bytecode.annotation.Annotation next : anns) {
+                if(!next.getTypeName().equals(WebService.class.getName()))
+                    continue;
+                try {
+                    return new Type(classFile, (WebService) (next.toAnnotationType(Sei.class.getClassLoader(), CLASS_POOL)));
+                } catch (ClassNotFoundException e) {
+                    throw new MojoExecutionException("Problem finding class for annotation: " + e.getMessage(), e);
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/codehaus/mojo/jaxws/TestWsGenMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxws/TestWsGenMojo.java
@@ -136,7 +136,7 @@ public class TestWsGenMojo
     }
 
     @Override
-    protected String getExtraClasspath()
+    protected String getExtraClasspath() throws MojoExecutionException
     {
         String cp = super.getExtraClasspath();
         StringBuilder buf = new StringBuilder();


### PR DESCRIPTION
The sei lookup in case of default classpath lookup failed to load classes - fixed with proper dependencies (compile+provided+system) classpath.

Added new sei lookup strategy - javassist which does not require class loading but reads class byte code

Added new file state registry which tracks sei class files md5 checksums and in case of incremental rebuild it will not execute wsgen tool if the generated artifacts are missing. (Useful in eclipse)

