### PR TITLE
Updated to support JDK 9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,11 +117,10 @@
   </ciManagement>
 
   <properties>
-    <jaxws-tools.version>2.2.10</jaxws-tools.version>
-    <netbeans.hint.jdkPlatform>JDK_1.6</netbeans.hint.jdkPlatform>
+    <netbeans.hint.jdkPlatform>JDK_1.8</netbeans.hint.jdkPlatform>
     <scmpublish.content>${project.build.directory}/staging/jaxws-maven-plugin</scmpublish.content>
-    <mavenVersion>3.0</mavenVersion>
-    <mojo.java.target>1.6</mojo.java.target>
+    <mavenVersion>3.5.4</mavenVersion>
+    <mojo.java.target>1.8</mojo.java.target>
   </properties>
 
   <dependencyManagement>
@@ -129,12 +128,12 @@
       <dependency>
         <groupId>com.sun.xml.ws</groupId>
         <artifactId>jaxws-tools</artifactId>
-        <version>${jaxws-tools.version}</version>
+        <version>2.3.0.2</version>
       </dependency>
       <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-utils</artifactId>
-        <version>3.0.22</version>
+        <groupId>com.sun.activation</groupId>
+        <artifactId>javax.activation</artifactId>
+        <version>1.2.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -143,8 +142,11 @@
     <dependency>
       <groupId>com.sun.xml.ws</groupId>
       <artifactId>jaxws-tools</artifactId>
-      <scope>runtime</scope>
     </dependency>
+    <dependency>
+	  <groupId>com.sun.activation</groupId>
+	  <artifactId>javax.activation</artifactId>
+	</dependency>
 
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -172,12 +174,9 @@
       <version>${mavenVersion}</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.5.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -194,6 +193,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
+          <version>3.5.2</version>
           <configuration>
             <extractors>
               <extractor>java-annotations</extractor>

--- a/src/main/java/org/codehaus/mojo/jaxws/AbstractJaxwsMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxws/AbstractJaxwsMojo.java
@@ -160,6 +160,15 @@ abstract class AbstractJaxwsMojo
      */
     @Parameter( defaultValue = "false" )
     private boolean useJdkToolchainExecutable;
+    
+    /**
+     * Set the <code>javax.xml.accessExternalSchema=all</code> JAXP 1.5 argument 
+     *
+     * @since 2.6
+     */
+    @Parameter( defaultValue = "true" )
+    private boolean accessExternalSchema;
+    
 
     /**
      * The current build session instance. This is used for toolchain manager API calls.
@@ -439,7 +448,13 @@ abstract class AbstractJaxwsMojo
                 }
             }
             InvokerCP classpath = getInvokerCP();
-            cmd.createArg().setValue( "-Xbootclasspath/p:" + classpath.ecp );
+            if(endorsedSupported()) {
+            	cmd.createArg().setValue( "-Xbootclasspath/p:" + classpath.ecp );
+            }
+            if (accessExternalSchema)
+            {
+            	cmd.createArg().setValue( "-Djavax.xml.accessExternalSchema=all" );
+            }
             cmd.createArg().setValue( "-cp" );
             cmd.createArg().setValue( classpath.invokerPath );
             cmd.createArg().setLine( Invoker.class.getCanonicalName() );
@@ -674,7 +689,7 @@ abstract class AbstractJaxwsMojo
      */
     private void addArtifactToCp( Artifact a, Map<String, Artifact> artifactsMap, Set<Artifact> endorsedArtifacts )
     {
-        if ( isEndorsedArtifact( a ) )
+        if ( endorsedSupported() && isEndorsedArtifact( a ) )
         {
             endorsedArtifacts.add( a );
         }
@@ -691,6 +706,11 @@ abstract class AbstractJaxwsMojo
             vmArgs = new ArrayList<String>();
         }
         vmArgs.add( vmArg );
+    }
+    
+    private boolean endorsedSupported()
+    {
+    	return Double.parseDouble(System.getProperty("java.specification.version")) <= 1.8;
     }
 
     private boolean isEndorsedArtifact( Artifact a )


### PR DESCRIPTION
#67 - Updated to use latest RI tools version, made endorsed bootclasspath argument contingent on JDK version, added option to automatically set accessExternalSchema.