### PR TITLE
Switch to Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ env:
   - MAVEN_VERSION=3.0.5
   - MAVEN_VERSION=3.3.9
 jdk:
-  - openjdk7
-  - oraclejdk7
   - oraclejdk8
 addons:
   # Required to avoid openjdk7 buffer overflow:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
   - MAVEN_VERSION=3.0.5
   - MAVEN_VERSION=3.3.9
 jdk:
-  - oraclejdk8
+  - openjdk8
 addons:
   # Required to avoid openjdk7 buffer overflow:
   # https://github.com/travis-ci/travis-ci/issues/5227

--- a/pom.xml
+++ b/pom.xml
@@ -118,10 +118,10 @@
 
   <properties>
     <jaxws-tools.version>2.2.10</jaxws-tools.version>
-    <netbeans.hint.jdkPlatform>JDK_1.6</netbeans.hint.jdkPlatform>
+    <netbeans.hint.jdkPlatform>JDK_1.8</netbeans.hint.jdkPlatform>
     <scmpublish.content>${project.build.directory}/staging/jaxws-maven-plugin</scmpublish.content>
     <mavenVersion>3.0</mavenVersion>
-    <mojo.java.target>1.6</mojo.java.target>
+    <mojo.java.target>1.8</mojo.java.target>
   </properties>
 
   <dependencyManagement>
@@ -269,24 +269,6 @@
   </reporting>
 
   <profiles>
-    <profile>
-      <!-- This is only for non MAC OS X builds, hence the property below -->
-      <id>default-tools.jar</id>
-      <activation>
-        <file>
-          <exists>${java.home}/../lib/tools.jar</exists>
-        </file>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>com.sun</groupId>
-          <artifactId>tools</artifactId>
-          <version>1.6.0</version>
-          <scope>system</scope>
-          <systemPath>${java.home}/../lib/tools.jar</systemPath>
-        </dependency>
-      </dependencies>
-    </profile>
     <profile>
       <id>coverage</id>
       <activation>

--- a/src/main/java/org/codehaus/mojo/jaxws/Invoker.java
+++ b/src/main/java/org/codehaus/mojo/jaxws/Invoker.java
@@ -59,17 +59,16 @@ public final class Invoker
             idx = 3;
         }
 
-        URLClassLoader cl = new URLClassLoader( toUrls( cp ) );
-
         // save original classloader and java.class.path property
         ClassLoader orig = Thread.currentThread().getContextClassLoader();
         String origJcp = System.getProperty( "java.class.path" );
 
-        // set to values for tool invocation
-        Thread.currentThread().setContextClassLoader( cl );
-        System.setProperty( "java.class.path", cp );
-        try
+        try ( URLClassLoader cl = new URLClassLoader( toUrls( cp ) ) )
         {
+            // set to values for tool invocation
+            Thread.currentThread().setContextClassLoader( cl );
+            System.setProperty( "java.class.path", cp );
+
             Class<?> toolClass = cl.loadClass( toolClassname );
 
             Object tool = toolClass.getConstructor( OutputStream.class ).newInstance( System.out );

--- a/src/main/java/org/codehaus/mojo/jaxws/Invoker.java
+++ b/src/main/java/org/codehaus/mojo/jaxws/Invoker.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.jaxws;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -51,7 +52,9 @@ public final class Invoker
             File pathFile = new File( args[2] );
             pathFile.deleteOnExit();
             Properties p = new Properties();
-            p.load( new FileInputStream( pathFile ) );
+            try ( InputStream is = new FileInputStream( pathFile ) ) {
+                p.load( is );
+            }
             cp = p.getProperty( "cp" );
             idx = 3;
         }
@@ -121,7 +124,7 @@ public final class Invoker
 
     private static URL[] toUrls( String c )
     {
-        List<URL> urls = new ArrayList<URL>();
+        List<URL> urls = new ArrayList<>();
         for ( String s : c.split( File.pathSeparator ) )
         {
             try

--- a/src/main/java/org/codehaus/mojo/jaxws/MainWsImportMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxws/MainWsImportMojo.java
@@ -37,8 +37,8 @@
 package org.codehaus.mojo.jaxws;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -106,22 +106,11 @@ public class MainWsImportMojo
     @Override
     protected List<String> getWSDLFileLookupClasspathElements()
     {
-        List<String> list = new ArrayList<String>();
-
-        for ( Artifact a : project.getDependencyArtifacts() )
-        {
-            if ( Artifact.SCOPE_COMPILE.equals( a.getScope() )
-                    || Artifact.SCOPE_PROVIDED.equals( a.getScope() )
-                    || Artifact.SCOPE_SYSTEM.equals( a.getScope() ) )
-            {
-                File file = a.getFile();
-                if ( file != null )
-                {
-                    list.add( file.getPath() );
-                }
-            }
-        }
-
-        return list;
+        return project.getDependencyArtifacts().stream()
+                .filter( a -> (Artifact.SCOPE_COMPILE.equals( a.getScope() )
+                        || Artifact.SCOPE_PROVIDED.equals( a.getScope() )
+                        || Artifact.SCOPE_SYSTEM.equals( a.getScope()) )
+                        && null != a.getFile() )
+                .map( a -> a.getFile().getPath() ).collect( Collectors.toList() );
     }
 }

--- a/src/main/java/org/codehaus/mojo/jaxws/TestWsImportMojo.java
+++ b/src/main/java/org/codehaus/mojo/jaxws/TestWsImportMojo.java
@@ -37,8 +37,8 @@
 package org.codehaus.mojo.jaxws;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -135,21 +135,10 @@ public class TestWsImportMojo
     @Override
     protected List<String> getWSDLFileLookupClasspathElements() 
     {
-        List<String> list = new ArrayList<String>();
-
-        for ( Artifact a : project.getDependencyArtifacts() )
-        {
-            if ( !Artifact.SCOPE_RUNTIME.equals( a.getScope() ) )
-            {
-                File file = a.getFile();
-                if ( file != null )
-                {
-                    list.add( file.getPath() );
-                }
-            }
-        }
-
-        return list;
+        return project.getDependencyArtifacts().stream()
+                .filter( a -> !Artifact.SCOPE_RUNTIME.equals(a.getScope() )
+                        && null != a.getFile() )
+                .map( a -> a.getFile().getPath() ).collect( Collectors.toList() );
     }
 
     @Override

--- a/src/test/java/org/codehaus/mojo/jaxws/Assertions.java
+++ b/src/test/java/org/codehaus/mojo/jaxws/Assertions.java
@@ -50,21 +50,12 @@ public class Assertions
         File f = new File( project, path );
         Assert.assertTrue( f.exists(), f.getAbsolutePath() + " does not exist" );
         Assert.assertTrue( f.isFile(), f.getAbsolutePath() + " is not a file" );
-        BufferedReader r = new BufferedReader( new FileReader( f ) );
-        try
+        try ( BufferedReader r = new BufferedReader( new FileReader( f ) ) )
         {
-            String line;
-            while ( ( line = r.readLine() ) != null )
+            if ( r.lines().filter( l -> l.contains(s) ).findFirst().isPresent() )
             {
-                if ( line.contains( s ) )
-                {
-                    return;
-                }
+                return;
             }
-        }
-        finally
-        {
-            r.close();
         }
         Assert.fail( "'" + s + "' is missing in:" + f.getAbsolutePath() );
     }
@@ -75,9 +66,10 @@ public class Assertions
         File f = new File( project, "target/" + jarName );
         Assert.assertTrue( f.exists(), f.getAbsolutePath() + " does not exist" );
         Assert.assertTrue( f.isFile(), f.getAbsolutePath() + " is not a file" );
-        ZipFile zf = new ZipFile( f );
-        Assert.assertNotNull( zf.getEntry( path ), "'" + path + "' is missing in: " + jarName );
-        zf.close();
+        try ( ZipFile zf = new ZipFile( f ) )
+        {
+            Assert.assertNotNull( zf.getEntry( path ), "'" + path + "' is missing in: " + jarName );
+        }
     }
 
     public static void assertJarNotContains( File project, String jarName, String path )
@@ -86,8 +78,9 @@ public class Assertions
         File f = new File( project, "target/" + jarName );
         Assert.assertTrue( f.exists(), f.getAbsolutePath() + " does not exist" );
         Assert.assertTrue( f.isFile(), f.getAbsolutePath() + " is not a file" );
-        ZipFile zf = new ZipFile( f );
-        Assert.assertNull( zf.getEntry( path ), "'" + path + "' is in: " + jarName );
-        zf.close();
+        try ( ZipFile zf = new ZipFile( f ) )
+        {
+            Assert.assertNull( zf.getEntry( path ), "'" + path + "' is in: " + jarName );
+        }
     }
 }

--- a/src/test/java/org/codehaus/mojo/jaxws/RepositoryITCase.java
+++ b/src/test/java/org/codehaus/mojo/jaxws/RepositoryITCase.java
@@ -41,14 +41,7 @@ public class RepositoryITCase
     {
         File projects = new File( System.getProperty( "it.projects.dir" ) );
         File wsDir = new File( new File( projects.getParentFile(), "it-repo" ), "com/sun/xml/ws" );
-        FilenameFilter ff = new FilenameFilter()
-        {
-            @Override
-            public boolean accept( File dir, String name )
-            {
-                return new File( dir, name ).isDirectory();
-            }
-        };
+        FilenameFilter ff = ( dir, name ) -> new File( dir, name ).isDirectory();
 
         File versions = new File( wsDir, "jaxws-rt" );
         List<String> list = Arrays.asList( versions.list( ff ) );

--- a/src/test/java/org/codehaus/mojo/jaxws/WsGenMojoITCase.java
+++ b/src/test/java/org/codehaus/mojo/jaxws/WsGenMojoITCase.java
@@ -181,7 +181,6 @@ public class WsGenMojoITCase
 
     @Test
     public void jaxwscommons91()
-        throws IOException
     {
         project = new File( PROJECTS_DIR, "jaxwscommons-91" );
 

--- a/src/test/java/org/codehaus/mojo/jaxws/WsImportMojoITCase.java
+++ b/src/test/java/org/codehaus/mojo/jaxws/WsImportMojoITCase.java
@@ -138,7 +138,6 @@ public class WsImportMojoITCase
 
     @Test
     public void jaxwscommons49()
-        throws IOException
     {
         project = new File( PROJECTS_DIR, "jaxwscommons-49" );
 
@@ -163,7 +162,6 @@ public class WsImportMojoITCase
 
     @Test
     public void jaxwscommons87()
-        throws IOException
     {
         project = new File( PROJECTS_DIR, "jaxwscommons-87" );
 
@@ -174,7 +172,6 @@ public class WsImportMojoITCase
 
     @Test
     public void metro_wsimport()
-        throws IOException
     {
         project = new File( PROJECTS_DIR, "metro" );
 


### PR DESCRIPTION
- removed Java 7 from travis build
- usage of diamond operators and try-with-resources
- changed some long(er) expressions to shorter and more readable Lambda expressions
- minor fixes in AbstractJaxwsMojo#getInvokerCP() to prevent a possible error when classpath is empty